### PR TITLE
Referential sample size

### DIFF
--- a/Column.py
+++ b/Column.py
@@ -91,6 +91,7 @@ class Column:
 		self.referenced_schema = referenced_schema
 		self.referenced_table = referenced_table
 		self.referenced_column = referenced_column
+		self.referential_sample_size = None
 		self.cnx = cnx
 		self.table_name = table_name
 		self.cardinality = None
@@ -104,6 +105,14 @@ class Column:
 		self.null_percentage_chance = 0
 		if self.is_unique:
 			self.get_existing_values()
+	
+	def get_referential_values(self, rows_to_generate):
+		referential_sample_size = self.referential_sample_size
+		if self.is_unique:
+			referential_sample_size = rows_to_generate
+		elif self.cardinality != None:
+			referential_sample_size = self.cardinality
+		self.data_generator.get_referential_values(referential_sample_size)
 			
 	def generate_data(self, rows_to_generate):
 		if self.is_auto_inc == True or (self.is_nullable and random.randrange(1,100) <= self.null_percentage_chance):
@@ -135,4 +144,3 @@ class Column:
 				return data_val
 			elif self.is_data_quoted == True:
 				return "'%s'" % (data_val)
-

--- a/GenerateReferential.py
+++ b/GenerateReferential.py
@@ -13,12 +13,12 @@ class GenerateReferential:
 		self.possible_values = []
 		self.values_generated = 0
 
-	def get_referential_values(self):
+	def get_referential_values(self, referential_sample_size):
 		cursor = self.cnx.cursor()
 		query = ("SELECT DISTINCT `%s` "
 			"FROM `%s`.`%s` "
 			"WHERE `%s` IS NOT NULL "
-			"LIMIT 10000" % (self.reference_column, self.reference_schema, self.reference_table, self.reference_column))
+			"LIMIT %s" % (self.reference_column, self.reference_schema, self.reference_table, self.reference_column, str(referential_sample_size)))
 		cursor.execute(query)
 		for row in cursor.fetchall():
 			self.possible_values.append(row[0])

--- a/Main.py
+++ b/Main.py
@@ -48,6 +48,7 @@ argparser.add_argument("-m", "--menu", action='store_true', help="Use this if yo
 argparser.add_argument("--default_rows_per_insert", default=50, type=int, help="The default number of rows to create per insert statement.")
 argparser.add_argument("--default_null_percentage_chance", default=5, type=int, help="The percentage likelihood of a null being passed into a nullable field")
 argparser.add_argument("--default_cardinality", default=None, type=int, help="The percentage likelihood of a null being passed into a nullable field")
+argparser.add_argument("--default_referential_sample_size", default=5000, type=int, help="This sets the number of values that will be retrieved from the databases when generating data from a referential source.  Reducing this number will reduce cardinality, but will also reduce the amount of memory used by the program.  Note that a cardinality property or a unique column will override referential sample size")
 argparser.add_argument("--safety_off", action='store_true', help="Puts the tool in unsafe mode, which allows you generate data in schemas that already have data in them.  Please note that in some cases, this can use a lot of memory, use at your own risk")
 argparser.add_argument("--no_bin_log", action='store_true', help="Disabled writing to the bin log for this session")
 
@@ -68,7 +69,7 @@ set_mysql_session_variables(cnx, args.no_bin_log)
 print "Loading information about %s schema.  Please wait." % (mysql_schema_name)
 mysql_schema = Schema(cnx, mysql_schema_name)
 mysql_schema.set_table_defaults(args.default_rows_to_create, args.default_rows_per_insert)
-mysql_schema.set_column_defaults(args.default_null_percentage_chance, args.default_cardinality)
+mysql_schema.set_column_defaults(args.default_null_percentage_chance, args.default_cardinality, args.default_referential_sample_size)
 #TODO: possible split validation into it's own class
 		
 menu = Menu(mysql_schema)

--- a/Main.py
+++ b/Main.py
@@ -64,14 +64,15 @@ else:
 	cnx = MySQLdb.connect(host=args.host, user=args.user, passwd=args.password, port=args.port)
 
 	
-mysql_schema_name = validate_schema_name(args.database, get_schema_list(cnx))
+# TODO: Fix when working on menu / validation "mysql_schema_name = validate_schema_name(args.database, get_schema_list(cnx))
+mysql_schema_name = args.database
+#TODO: possible split validation into it's own class
 set_mysql_session_variables(cnx, args.no_bin_log)
 print "Loading information about %s schema.  Please wait." % (mysql_schema_name)
 mysql_schema = Schema(cnx, mysql_schema_name)
 mysql_schema.set_table_defaults(args.default_rows_to_create, args.default_rows_per_insert)
 mysql_schema.set_column_defaults(args.default_null_percentage_chance, args.default_cardinality, args.default_referential_sample_size)
-#TODO: possible split validation into it's own class
-		
+
 menu = Menu(mysql_schema)
 menu.validate_all_tables_rows_to_be_created()
 menu.validate_safety(args.safety_off)

--- a/Schema.py
+++ b/Schema.py
@@ -79,11 +79,12 @@ class Schema:
 			table.rows_to_generate = rows_to_generate
 			table.rows_per_insert = rows_per_insert
 	
-	def set_column_defaults(self, null_percentage_chance, cardinality):
+	def set_column_defaults(self, null_percentage_chance, cardinality, referential_sample_size):
 		for table in self.tables:
 			for column in table.columns:
 				column.null_percentage_chance = null_percentage_chance
 				column.cardinality = cardinality
+				column.referential_sample_size = referential_sample_size
 				
 	def generate_data(self):
 		self.mysql_change_schema_focus()

--- a/Table.py
+++ b/Table.py
@@ -81,7 +81,7 @@ class Table:
 	def get_column_referential_values(self):
 		for column in self.columns:
 			if column.referenced_table != None and column.data_generator.values_generated == 0:
-				column.data_generator.get_referential_values()
+				column.get_referential_values(self.rows_to_generate)
 		
 	def insert_data(self):
 		itr_rows_to_generate = 0


### PR DESCRIPTION
Gives the user the flexibility to see a default referential sample size.  This may reduce cardinality where not otherwise specified (or not in the case of a unique value), but will reduce the amount of values that need to be stored in memory during the data loading process.
